### PR TITLE
Migration rework

### DIFF
--- a/docs/Protocol Specifications/core.md
+++ b/docs/Protocol Specifications/core.md
@@ -5,7 +5,7 @@ weight: 0
 
 # polyproto Specification
 
-**v1.0.0-alpha.18** - Treat this as an unfinished draft.
+**v1.0.0-alpha.19** - Treat this as an unfinished draft.
 
 [Semantic versioning v2.0.0](https://semver.org/spec/v2.0.0.html) is used to version this specification.
 The version number specified here also applies to the API documentation.

--- a/docs/Protocol Specifications/core.md
+++ b/docs/Protocol Specifications/core.md
@@ -820,23 +820,27 @@ TODO more text?
 
 ### 7.1.1 Redirects
 
-Setting up a redirect is an optional step in the identity migration process. It allows for a
-smoother transition from the old account to the new account. This step is not necessary for the
-migration to be successful.
+Setting up a redirect is an optional step in the identity migration process, helping
+make the transition from the old account to the new account smoother.
+
+!!! info
+
+    "Optional" does not mean that home servers can choose to not implement this feature. Instead,
+    it means that actors can choose to not use this feature.
 
 ```mermaid
 sequenceDiagram
 autonumber
 
-actor aa as Alice A
-actor ab as Alice B
+actor aa as Alice A (Redirection source)
+actor ab as Alice B (Redirection target)
 participant sa as Server A
 participant sb as Server B
 
 aa->>sa: Request redirect to Alice B
 sa->>aa: List of keys to verify + challenge string
 aa->>sa: Completed challenge for each key on the list
-aa->>aa: Set redirect status to "unconfirmed by target"
+aa->>aa: Set redirect status to "unconfirmed by redirection source"
 ab->>sa: Request redirect from Alice A
 sa->>sa: Set redirect status to "confirmed"
 sa->>sa: Use HTTP 307 to redirect all requests for Alice A to Alice B
@@ -846,10 +850,10 @@ sa->>sa: Use HTTP 307 to redirect all requests for Alice A to Alice B
 
 /// TODO Update Fig. numbers from here
 
-Until Alice A deletes her account, Server A should respond with a `307 Temporary Redirect` to
-requests for information about or for Alice A. After Alice A deletes her account, Server A should
-either respond with `308 Permanent Redirect` or remove the redirect entirely.
-
+Until a redirection source actor deletes their account, the home server of that actor should respond
+with `307 Temporary Redirect` to requests for information about the redirection source. After
+the redirection source deletes their account, Server A can select to either respond with
+`308 Permanent Redirect`, or to remove the redirect entirely.
 
 #### 7.2 Re-signing data
 

--- a/docs/Protocol Specifications/core.md
+++ b/docs/Protocol Specifications/core.md
@@ -1063,8 +1063,8 @@ aa-xsa: Deactivate account
 
 *Fig. 8: Sequence diagram depicting the data moving process.*
 
-Depending on the use case, this process can be adapted to fit the needs of the user. How this process
-is implemented is up to the concrete implementation.
+How this process is implemented is up to P2 extensions to define. The above steps are only a
+guideline. The API routes for data export and import are documented in the API documentation.
 
 ### 7.4 Challenges and trust
 
@@ -1079,7 +1079,8 @@ with the new signature is created, preserving the old message.
 All challenge strings and their responses created in the context of account migration must be made
 public to ensure that a chain of trust can be maintained. A third party should be able to verify that
 the challenge string, which authorized the ownership change of an accounts' data was signed by the
-correct private key.
+correct private key. The API routes needed to verify challenges as an outsider are documented in the
+API documentation.
 
 Implementations and protocol extensions should carefully consider the extent of messages that can be
 re-signed.

--- a/docs/Protocol Specifications/core.md
+++ b/docs/Protocol Specifications/core.md
@@ -46,13 +46,13 @@ The version number specified here also applies to the API documentation.
     - [7.3 Moving data](#73-moving-data)
     - [7.4 Challenges and trust](#74-challenges-and-trust)
   - [8. Protocol extensions (P2 extensions)](#8-protocol-extensions-p2-extensions)
-  - [8.1 Extension design](#81-extension-design)
-  - [8.2 Namespaces](#82-namespaces)
-  - [8.3 Officially endorsed extensions](#83-officially-endorsed-extensions)
-  - [8.4 Versioning and yanking](#84-versioning-and-yanking)
-    - [8.4.1 Yanking](#841-yanking)
-    - [8.4 Dependencies](#84-dependencies)
-  - [8.5 Routes](#85-routes)
+    - [8.1 Extension design](#81-extension-design)
+    - [8.2 Namespaces](#82-namespaces)
+    - [8.3 Officially endorsed extensions](#83-officially-endorsed-extensions)
+    - [8.4 Versioning and yanking](#84-versioning-and-yanking)
+      - [8.4.1 Yanking](#841-yanking)
+    - [8.5 Dependencies](#85-dependencies)
+    - [8.6 Routes](#86-routes)
   - [9. Services](#9-services)
   - [9.1 Discoverability](#91-discoverability)
     - [9.1.1 Changing a primary service provider](#911-changing-a-primary-service-provider)
@@ -1018,7 +1018,7 @@ define:
 - how protocol extensions interact with the core protocol
 - requirements, which must be fulfilled by protocol extensions to become officially endorsed
 
-## 8.1 Extension design
+### 8.1 Extension design
 
 P2 extensions *should* be either of the following:
 
@@ -1046,7 +1046,7 @@ more comprehensive set of features.
     P2 extensions are useful for defining interoperable services, which can be implemented by a variety
     of servers and clients.
 
-## 8.2 Namespaces
+### 8.2 Namespaces
 
 A namespace is a string used to identify a specific P2 extension. Used as a prefix in URLs, they
 prevent route name collisions between different extensions. Namespaces should be unique
@@ -1057,7 +1057,7 @@ taken by an officially endorsed extension, a different namespace must be chosen.
 collision exists between an officially endorsed extension and a regular P2 extension, the officially
 endorsed extension has priority.
 
-## 8.3 Officially endorsed extensions
+### 8.3 Officially endorsed extensions
 
 Officially endorsed extensions are extensions that either:
 
@@ -1074,14 +1074,14 @@ Officially endorsed extensions must fulfill all the requirements listed in
 Each version of an extension developed by outside parties must undergo the review process before
 being officially endorsed.
 
-## 8.4 Versioning and yanking
+### 8.4 Versioning and yanking
 
 Semantic Versioning v2.0.0 is used for versioning P2 extensions. The version number of an extension
 is defined in the extension's documentation. The version number must be updated whenever a change is
 made to the extension. The only exception to this rule is when marking an extension as deprecated
 (yanking).
 
-### 8.4.1 Yanking
+#### 8.4.1 Yanking
 
 Yanking an extension means that the extension is no longer supported, and that it **should not** be used.
 A later version of the extension should be used instead. Yanked extension versions should prominently
@@ -1089,7 +1089,7 @@ display the "yanked" status next to the version number in the extension's docume
 
 Versions of officially endorsed P2 extensions can normally not be removed, only marked as yanked.
 
-### 8.4 Dependencies
+### 8.5 Dependencies
 
 P2 extensions can depend on other P2 extensions. If an extension depends on another extension, the
 name of the dependency must be listed in the extension's documentation, along with a link to the
@@ -1133,7 +1133,7 @@ officially endorsed P2 extensions.
 Doing this ensures a high level of interoperability across all different implementations of a specific
 application group.
 
-## 8.5 Routes
+### 8.6 Routes
 
 Polyproto extensions must never change, add or remove routes defined by the extension they depend on.
 Instead, routes with alternating or new behavior must be added under a newly defined namespace, which


### PR DESCRIPTION
This PR refines how migrations of messages and user identities work in polyproto. More "sane" use-cases have been considered, with the process of migrating messages having been made more flexible to match.

The considered use cases of changing message ownership are:

- Changing ownership of messages from one actor to another. This enables seamless transitions
between accounts, while preserving the integrity of the messages.
- Reducing the amount of keys that need to be remembered by an actor, done if the actor deems it to
be convenient.
- "Rotate keys of past messages" - This is useful when an actor's private identity key has been
compromised, and the actor wants to ensure that all messages sent by them are still owned by them
and not at risk of being tampered with.

The API routes needed to support this new behavior are still missing. However, these will be added as these changes get merged into the polyproto crate.